### PR TITLE
Remove premature truncation of code to 6 digits. And only build for .…

### DIFF
--- a/src/Otp.NET/Otp.NET.csproj
+++ b/src/Otp.NET/Otp.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Version>1.3.0</Version>
-    <TargetFrameworks>net461;net5.0;net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PackageId>Otp.NET</PackageId>
     <Title>Otp.NET</Title>
     <Authors>Kyle Spearrin</Authors>

--- a/src/Otp.NET/Otp.cs
+++ b/src/Otp.NET/Otp.cs
@@ -105,7 +105,7 @@ public abstract class Otp
         return (hmacComputedHash[offset] & 0x7f) << 24
             | (hmacComputedHash[offset + 1] & 0xff) << 16
             | (hmacComputedHash[offset + 2] & 0xff) << 8
-            | (hmacComputedHash[offset + 3] & 0xff) % 1000000;
+            | (hmacComputedHash[offset + 3] & 0xff);
     }
 
     /// <summary>


### PR DESCRIPTION
…Net 8.